### PR TITLE
Update `export_as_txt` to print split label when using `page_by` with one level

### DIFF
--- a/R/pagination.R
+++ b/R/pagination.R
@@ -889,6 +889,10 @@ paginate_indices <- function(obj,
          pag_col_indices = pag_col_indices)
 }
 
+setGeneric("has_page_title", function(obj) standardGeneric("has_page_title"))
+
+setMethod("has_page_title", "ANY", function(obj) length(page_titles(obj)) > 0)
+
 #' @rdname paginate_indices
 #' @export
 paginate_to_mpfs <- function(obj,
@@ -958,7 +962,7 @@ paginate_to_mpfs <- function(obj,
                       nosplitin = nosplitin,
                       verbose = verbose)
         return(unlist(deep_pag, recursive = FALSE))
-    } else if (!is.null(attr(obj, "page_title_prefix")) && !is.na(attr(obj, "page_title_prefix"))) {
+    } else if (has_page_title(fpags[[1]])) {
       obj <- fpags[[1]]
     }
 

--- a/R/pagination.R
+++ b/R/pagination.R
@@ -958,6 +958,8 @@ paginate_to_mpfs <- function(obj,
                       nosplitin = nosplitin,
                       verbose = verbose)
         return(unlist(deep_pag, recursive = FALSE))
+    } else if (!is.null(attr(obj, "page_title_prefix")) && !is.na(attr(obj, "page_title_prefix"))) {
+      obj <- fpags[[1]]
     }
 
 

--- a/tests/testthat/test-exporters.R
+++ b/tests/testthat/test-exporters.R
@@ -116,27 +116,3 @@ test_that("exporters work", {
                          paste(c(expct_lns[1:5], ""), collapse = "\n"))
     })
 })
-
-test_that("export_as_txt prints split level header when using page_by with only one level", {
-    tbl <- basic_table() %>%
-        split_rows_by("PARAMCD", labels_var = "PARAMCD", split_label = "aaa",
-                      label_pos = "topleft",
-                      split_fun = drop_split_levels, page_by = TRUE) %>%
-        split_rows_by("AVISIT", label_pos = "topleft",
-                      split_fun = keep_split_levels("SCREENING")) %>%
-        summarize_vars("AVAL",
-                       .stats = c("n", "mean_sd")) %>%
-        build_table(ex_adlb %>% filter(PARAMCD == "ALT"))
-    tbl_txt <- tbl %>% export_as_txt(lpp = 100)
-
-    expect_txt <- paste0(
-        "\naaa: ALT\n\n",
-        "——————————————————————————\n",
-        "aaa                       \n",
-        "  AVISIT         all obs  \n",
-        "——————————————————————————\n",
-        "SCREENING                 \n",
-        "  n                400    \n",
-        "  Mean (SD)     50.3 (7.8)\n")
-    expect_identical(tbl_txt[[1]], expect_txt)
-})

--- a/tests/testthat/test-exporters.R
+++ b/tests/testthat/test-exporters.R
@@ -116,3 +116,27 @@ test_that("exporters work", {
                          paste(c(expct_lns[1:5], ""), collapse = "\n"))
     })
 })
+
+test_that("export_as_txt prints split level header when using page_by with only one level", {
+    tbl <- basic_table() %>%
+        split_rows_by("PARAMCD", labels_var = "PARAMCD", split_label = "aaa",
+                      label_pos = "topleft",
+                      split_fun = drop_split_levels, page_by = TRUE) %>%
+        split_rows_by("AVISIT", label_pos = "topleft",
+                      split_fun = keep_split_levels("SCREENING")) %>%
+        summarize_vars("AVAL",
+                       .stats = c("n", "mean_sd")) %>%
+        build_table(ex_adlb %>% filter(PARAMCD == "ALT"))
+    tbl_txt <- tbl %>% export_as_txt(lpp = 100)
+
+    expect_txt <- paste0(
+        "\naaa: ALT\n\n",
+        "——————————————————————————\n",
+        "aaa                       \n",
+        "  AVISIT         all obs  \n",
+        "——————————————————————————\n",
+        "SCREENING                 \n",
+        "  n                400    \n",
+        "  Mean (SD)     50.3 (7.8)\n")
+    expect_identical(tbl_txt[[1]], expect_txt)
+})


### PR DESCRIPTION
Closes https://github.com/insightsengineering/rtables/issues/653