### PR TITLE
Revert defaults to avoid `NULL` assigns before `rlistings`' PR

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## formatters 0.5.0.9005
  * New generic `getter` and `setter` for `align` (`obj_align` and `obj_align<-`).
  * New `fmt_config` class to bundle together `format`, `na_str`, and `align` instructions.
+ * Reverting default for alignment (from `NULL` to `center`) and `na_str` 
+   from `NULL` to `"NA"`. This affects only `rlistings`, where the new default takes effect.
 
 ## formatters 0.5.0
  * fix bug in `MPF` pagination (and thus export_as_txt) when column labels had newlines ([#150](github.com/insightsengineering/formatters/issues/150), [`insightsengineering/rtables#634`](https://github.com/insightsengineering/rtables/issues/634))

--- a/R/format_value.R
+++ b/R/format_value.R
@@ -411,6 +411,6 @@ setClass("fmt_config",
 #' fmt_config(format = "xx.xx - xx.xx", align = "right")
 #'
 #' @export
-fmt_config <- function(format = NULL, na_str = NULL, align = NULL) {
+fmt_config <- function(format = NULL, na_str = "NA", align = "center") {
   new("fmt_config", format = format, format_na_str = na_str, align = align)
 }

--- a/man/fmt_config.Rd
+++ b/man/fmt_config.Rd
@@ -4,7 +4,7 @@
 \alias{fmt_config}
 \title{Format Configuration}
 \usage{
-fmt_config(format = NULL, na_str = NULL, align = NULL)
+fmt_config(format = NULL, na_str = "NA", align = "center")
 }
 \arguments{
 \item{format}{character(1) or function. A format label (string) or \code{formatter} function.}

--- a/tests/testthat/test-formatters.R
+++ b/tests/testthat/test-formatters.R
@@ -543,8 +543,8 @@ expect_equal(length(grep("spn_val", toString(mpf))),
 test_that("fmt_config works as expected", {
   x <- fmt_config()
   expect_identical(obj_format(x), NULL)
-  expect_identical(obj_na_str(x), NULL)
-  expect_identical(obj_align(x), NULL)
+  expect_identical(obj_na_str(x), "NA")
+  expect_identical(obj_align(x), "center")
 
   x <- fmt_config(format = "xx.xx", na_str = "<Missing>", align = "right")
   expect_identical(obj_format(x), "xx.xx")


### PR DESCRIPTION
Fixes #180