### PR TITLE
Reinstate defaults to `NULL`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
 ## formatters 0.5.0.9006
  * New generic `getter` and `setter` for `align` (`obj_align` and `obj_align<-`).
  * New `fmt_config` class to bundle together `format`, `na_str`, and `align` instructions.
- * Reverting default for alignment (from `NULL` to `center`) and `na_str` 
-   from `NULL` to `"NA"`. This affects only `rlistings`, where the new default takes effect.
+ * Default for `fmt_config` alignment and `na_str` set to `NULL`. The default values are set in `rlistings`.
 
 ## formatters 0.5.0
  * fix bug in `MPF` pagination (and thus export_as_txt) when column labels had newlines ([#150](github.com/insightsengineering/formatters/issues/150), [`insightsengineering/rtables#634`](https://github.com/insightsengineering/rtables/issues/634))

--- a/R/format_value.R
+++ b/R/format_value.R
@@ -411,6 +411,6 @@ setClass("fmt_config",
 #' fmt_config(format = "xx.xx - xx.xx", align = "right")
 #'
 #' @export
-fmt_config <- function(format = NULL, na_str = "NA", align = "center") {
+fmt_config <- function(format = NULL, na_str = NULL, align = NULL) {
   new("fmt_config", format = format, format_na_str = na_str, align = align)
 }

--- a/man/fmt_config.Rd
+++ b/man/fmt_config.Rd
@@ -4,7 +4,7 @@
 \alias{fmt_config}
 \title{Format Configuration}
 \usage{
-fmt_config(format = NULL, na_str = "NA", align = "center")
+fmt_config(format = NULL, na_str = NULL, align = NULL)
 }
 \arguments{
 \item{format}{character(1) or function. A format label (string) or \code{formatter} function.}


### PR DESCRIPTION
`formatters` should not set defaults beforehand on `fmt_config` as they will be different for `rtables` and `rlistings`. Setting them to `NULL` here will trigger the defaults in `rlistings` that make `align="left"` global default.

After this we will have to update the default snapshots in `chevron` @BFalquet @clarkliming and `scda.test` @shajoezhu. Whenever you want, we can go ;)