### PR TITLE
Fixing infinite loop for specific strings (e.g. "10  . 4", width of 2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
  * Fixed wrapping and section dividers error.
  * Allowed section divider between header and table body.
  * Added the possibility of setting a general default using `set_default_hsep()` that sets up the option `getOption("formatters_default_hsep")`.
+ * Fixed infinite loop in `wrap_string` that was caused by a bug in `stringi::stri_wrap` not wrapping small
+   strings with dots and spaces correctly.
 
 ## formatters 0.5.4
  * Fixed a bug in `paginate_to_mpfs()` so that formatting in listings key columns is retained with pagination [`insightsengineering/rlistings#155`](https://github.com/insightsengineering/rlistings/issues/155).

--- a/R/tostring.R
+++ b/R/tostring.R
@@ -817,13 +817,17 @@ wrap_string <- function(str, width, collapse = NULL) {
       # Checking if we are stuck in a loop
       ori_wrapped_txt_v <- .go_stri_wrap(str, width)
       cur_wrapped_txt_v <- .go_stri_wrap(ret_collapse, width)
-      if (!setequal(ori_wrapped_txt_v, cur_wrapped_txt_v)) {
-        return(wrap_string(str = ret_collapse, width = width, collapse = collapse))
-      } else {
+      broken_char_ori <- sum(nchar(ori_wrapped_txt_v) > width) # how many issues there were
+      broken_char_cur <- sum(nchar(cur_wrapped_txt_v) > width) # how many issues there are
+
+      if (setequal(ori_wrapped_txt_v, cur_wrapped_txt_v) ||
+          broken_char_cur >= broken_char_ori) { # we did not solve the current issue!
         # help function: Very rare case where the recursion is stuck in a loop
         ret_tmp <- force_split_words_by(ret[we_interval], width) # here we_interval is only one ind
         ret <- append(ret, ret_tmp, we_interval)[-we_interval]
         which_exceeded <- which(nchar(ret) > width)
+      } else {
+        return(wrap_string(str = ret_collapse, width = width, collapse = collapse))
       }
     }
   }

--- a/tests/testthat/test-txt_wrap.R
+++ b/tests/testthat/test-txt_wrap.R
@@ -205,6 +205,13 @@ test_that("wrap_strings work", {
   # Check for avoidance of infinite loops - C stack exceeding
   expect_identical(wrap_string("6.5", 1), c("6", ".", "5"))
   expect_silent(wrap_string("6.5 and something else. 4.3", 1))
+
+  # Second case of loop (different length - check breaks)
+  expect_identical(formatters::wrap_string("10. 1 6.5", 2), c("10", " .", "1", "6.", "5"))
+  expect_identical(
+    formatters::wrap_string("10  . 1 6.5 5 . 4", 2),
+    c("10", " .", "1", "6.", "5", "5 ", " .", "4")
+  )
 })
 
 test_that("toString wrapping avoid trimming whitespaces", {


### PR DESCRIPTION
Fixes #230 