### PR TITLE
Add "N=xx" format to exactly match FDA example shells, with test updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## formatters 0.5.5.9001
+ * Added "N=xx" format and unit test for it
 
 ## formatters 0.5.5
  * Applied `styler` and resolved package lint. Changed default indentation from 4 spaces to 2.

--- a/R/format_value.R
+++ b/R/format_value.R
@@ -1,7 +1,7 @@
 formats_1d <- c(
   "xx", "xx.", "xx.x", "xx.xx", "xx.xxx", "xx.xxxx",
-  "xx%", "xx.%", "xx.x%", "xx.xx%", "xx.xxx%", "(N=xx)", ">999.9", ">999.99",
-  "x.xxxx | (<0.0001)", "N=xx"
+  "xx%", "xx.%", "xx.x%", "xx.xx%", "xx.xxx%", "(N=xx)", "N=xx", ">999.9", ">999.99",
+  "x.xxxx | (<0.0001)"
 )
 
 formats_2d <- c(

--- a/R/format_value.R
+++ b/R/format_value.R
@@ -1,7 +1,7 @@
 formats_1d <- c(
   "xx", "xx.", "xx.x", "xx.xx", "xx.xxx", "xx.xxxx",
   "xx%", "xx.%", "xx.x%", "xx.xx%", "xx.xxx%", "(N=xx)", ">999.9", ">999.99",
-  "x.xxxx | (<0.0001)"
+  "x.xxxx | (<0.0001)", "N=xx"
 )
 
 formats_2d <- c(
@@ -316,6 +316,7 @@ format_value <- function(x, format = NULL, output = c("ascii", "html"), na_str =
       "xx.xx%" = paste0(round_fmt(x * 100, digits = 2, na_str = na_str), "%"),
       "xx.xxx%" = paste0(round_fmt(x * 100, digits = 3, na_str = na_str), "%"),
       "(N=xx)" = paste0("(N=", round_fmt(x, digits = NA, na_str = na_str), ")"),
+      "N=xx" = paste0("N=", round_fmt(x, digits = NA, na_str = na_str)),
       ">999.9" = ifelse(x > 999.9, ">999.9", round_fmt(x, digits = 1, na_str = na_str)),
       ">999.99" = ifelse(x > 999.99, ">999.99", round_fmt(x, digits = 2, na_str = na_str)),
       "x.xxxx | (<0.0001)" = ifelse(x < 0.0001, "<0.0001", round_fmt(x, digits = 4, na_str = na_str)),

--- a/tests/testthat/test-formatters.R
+++ b/tests/testthat/test-formatters.R
@@ -300,6 +300,8 @@ test_that("formats work", {
   )
 
   expect_identical(format_value(c(500, 1), "N=xx (xx%)"), "N=500 (100%)")
+  expect_identical(format_value(c(500), "N=xx"), "N=500")
+  expect_identical(format_value(c(500), "(N=xx)"), "(N=500)")
 
   ## errors
 
@@ -783,7 +785,8 @@ test_that("All supported 1d format cases of decimal alignment", {
   bmf$strings[, 4] <- bmf$aligns[, 3] <- sample_list_aligns
 
   expect_error(cw <- propose_column_widths(bmf), regexp = "*1.1111 | (<0.0001)*")
-  bmf$aligns[nrow(bmf$aligns), c(2, 3)] <- "center"
+  notallowed <- grep("1.1111 | (<0.0001)", bmf$strings[,2], fixed = TRUE)
+  bmf$aligns[notallowed, c(2, 3)] <- "center"
   cw <- propose_column_widths(bmf)
   cw[3] <- cw[3] + 4
   res_dec <- strsplit(toString(bmf, widths = cw, hsep = "-"), "\\n")[[1]]
@@ -805,7 +808,8 @@ test_that("All supported 1d format cases of decimal alignment", {
     "l       (N=11)                       (N=11)       dec_right",
     "m        >999.9                          >999.9   right    ",
     "n        >999.99          >999.99                 dec_left ",
-    "o   1.1111 | (<0.0001)     1.1111 | (<0.0001)     dec_left "
+    "o   1.1111 | (<0.0001)     1.1111 | (<0.0001)     dec_left ",
+    "p        N=11                              N=11   right    "
   )
   expect_identical(res_dec, expected)
 })

--- a/tests/testthat/test-formatters.R
+++ b/tests/testthat/test-formatters.R
@@ -785,7 +785,7 @@ test_that("All supported 1d format cases of decimal alignment", {
   bmf$strings[, 4] <- bmf$aligns[, 3] <- sample_list_aligns
 
   expect_error(cw <- propose_column_widths(bmf), regexp = "*1.1111 | (<0.0001)*")
-  notallowed <- grep("1.1111 | (<0.0001)", bmf$strings[,2], fixed = TRUE)
+  notallowed <- grep("1.1111 | (<0.0001)", bmf$strings[, 2], fixed = TRUE)
   bmf$aligns[notallowed, c(2, 3)] <- "center"
   cw <- propose_column_widths(bmf)
   cw[3] <- cw[3] + 4


### PR DESCRIPTION
Small change to add "N=xx" format for use with column counts to exactly match FDA example shells. Closes #240 