### PR TITLE
Add snapshot testing job

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -46,8 +46,6 @@ jobs:
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
-      additional-env-vars: |
-        _R_CHECK_CRAN_INCOMING_REMOTE_=false
       enforce-note-blocklist: true
       publish-unit-test-report-gh-pages: false
       junit-xml-comparison: false
@@ -63,8 +61,6 @@ jobs:
         checking Rd .usage sections .* NOTE
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
-      unit-test-report-brand: >-
-        https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/tern.png
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main


### PR DESCRIPTION
Adds another R CMD check workflow that does non-CRAN checks and therefore executes snapshot tests.