### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Suggests:
     huxtable (>= 2.0.0),
     knitr (>= 1.42),
     r2rtf (>= 0.3.2),
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     stringi (>= 1.6),
     testthat (>= 3.0.4),
     withr (>= 2.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     lifecycle (>= 0.2.0)
 Suggests:
     dplyr (>= 1.0.9),
-    gt (>= 0.7.0),
+    gt (>= 0.10.0),
     huxtable (>= 2.0.0),
     knitr (>= 1.42),
     r2rtf (>= 0.3.2),


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.