### PR TITLE
fix: function crashes due to missing paginate argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: formatters
 Title: ASCII Formatting for Values and Tables
-Version: 0.5.10.9000
+Version: 0.5.10.9001
 Date: 2025-01-09
 Authors@R: c(
     person("Gabriel", "Becker", , "gabembecker@gmail.com", role = "aut",

--- a/R/mpf_exporters.R
+++ b/R/mpf_exporters.R
@@ -409,8 +409,8 @@ export_as_rtf <- function(x,
                           font_size = 8,
                           lineheight = 1,
                           fontspec = font_spec(font_family, font_size, lineheight),
+                          paginate = TRUE,
                           ...) {
-  paginate <- isTRUE(list(...)$paginate)
   # Processing lists of tables or listings
   if (.is_list_of_tables_or_listings(x)) {
     if (isFALSE(paginate)) {

--- a/R/mpf_exporters.R
+++ b/R/mpf_exporters.R
@@ -60,6 +60,9 @@ export_as_txt <- function(x,
                           page_num = default_page_number(),
                           fontspec = font_spec(font_family, font_size, lineheight),
                           col_gap = 3) {
+
+  
+  paginate <- isTRUE(list(...)$paginate)                          
   # Processing lists of tables or listings
   if (.is_list_of_tables_or_listings(x)) {
     if (isFALSE(paginate)) {

--- a/R/mpf_exporters.R
+++ b/R/mpf_exporters.R
@@ -60,9 +60,7 @@ export_as_txt <- function(x,
                           page_num = default_page_number(),
                           fontspec = font_spec(font_family, font_size, lineheight),
                           col_gap = 3) {
-
-  
-  paginate <- isTRUE(list(...)$paginate)                          
+                       
   # Processing lists of tables or listings
   if (.is_list_of_tables_or_listings(x)) {
     if (isFALSE(paginate)) {
@@ -412,6 +410,7 @@ export_as_rtf <- function(x,
                           lineheight = 1,
                           fontspec = font_spec(font_family, font_size, lineheight),
                           ...) {
+  paginate <- isTRUE(list(...)$paginate)
   # Processing lists of tables or listings
   if (.is_list_of_tables_or_listings(x)) {
     if (isFALSE(paginate)) {


### PR DESCRIPTION
Function crashes, because `paginate` is not argument of function.

Error:

```
Error in isFALSE(paginate) : object 'paginate' not found
```



