### PR TITLE
Listing key columns info not repeated when vertically spanning multiple pages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## formatters 0.5.10.9000
+* Fixed a bug in `mform_handle_newlines` that caused string matrix column names to be removed. This prevented paginated listing key column info from being repeated when vertically spanning multiple pages.
 
 ## formatters 0.5.10
 * Fixed a bug in `mf_update_cinfo` causing an error when `export_as_txt` was applied to empty listings.

--- a/R/matrix_form.R
+++ b/R/matrix_form.R
@@ -94,6 +94,7 @@ mform_handle_newlines <- function(matform) {
       ),
       expand_mat_rows(strmat[-1 * hdr_inds, , drop = FALSE], row_nlines[-hdr_inds])
     )
+    colnames(newstrmat) <- colnames(strmat)
 
     newfrmmat <- rbind(
       expand_mat_rows(

--- a/formatters.Rproj
+++ b/formatters.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 91d83c00-f38c-4245-80dc-783a2cfe8487
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/test-pagination.R
+++ b/tests/testthat/test-pagination.R
@@ -81,7 +81,7 @@ test_that("pagination works", {
   dfmf2 <- mform_handle_newlines(dfmf2)
   expect_identical(
     dfmf2$strings[1:2, 1:2],
-    matrix(c("", "tleft mats", "m", "pg"), nrow = 2, ncol = 2)
+    matrix(c("", "tleft mats", "m", "pg"), nrow = 2, ncol = 2, dimnames = list(NULL, c("rnms", "mpg")))
   )
 
   ## https://github.com/insightsengineering/formatters/issues/77


### PR DESCRIPTION
Closes #338 